### PR TITLE
Fix authentication issue in Golang sample code

### DIFF
--- a/docs/REST/authentication.md
+++ b/docs/REST/authentication.md
@@ -367,9 +367,9 @@ import (
 func SignRequest(id string, secret string, req *http.Request) error {
 	method := req.Method
 	host := req.URL.Host
-	pathAndQuery := req.URL.Path
-	if req.URL.RawQuery != "" {
-		pathAndQuery = pathAndQuery + "?" + req.URL.RawQuery
+	pathAndQuery := req.URL.EscapedPath()
+	if req.URL.Query().Encode() != "" {
+		pathAndQuery = pathAndQuery + "?" + req.URL.Query().Encode()
 	}
 
 	content, err := ioutil.ReadAll(req.Body)


### PR DESCRIPTION
The HMAC is calculated based on RawPath and RawQuery, which results in 401 Unauthorized error for API calls to key or label containing special characters. This change escapes the URL path and query to fix this issue.

Issue reported by user : https://github.com/Azure/AppConfiguration/issues/160