### PR TITLE
Revert "Fix authentication issue in Golang sample code (#161)"

### DIFF
--- a/docs/REST/authentication.md
+++ b/docs/REST/authentication.md
@@ -367,9 +367,9 @@ import (
 func SignRequest(id string, secret string, req *http.Request) error {
 	method := req.Method
 	host := req.URL.Host
-	pathAndQuery := req.URL.EscapedPath()
-	if req.URL.Query().Encode() != "" {
-		pathAndQuery = pathAndQuery + "?" + req.URL.Query().Encode()
+	pathAndQuery := req.URL.Path
+	if req.URL.RawQuery != "" {
+		pathAndQuery = pathAndQuery + "?" + req.URL.RawQuery
 	}
 
 	content, err := ioutil.ReadAll(req.Body)


### PR DESCRIPTION
This change reverts the additional encoding for Golang sample code. We need to better understand how encoding is being done in Golang in order to determine the right fix for this case.