### PR TITLE
Added authentication and authorization docs for AAD.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ The following reference pages are available to describe the Azure App Configurat
   * [Revisions](./docs/REST/revisions.md)
 
 **Protocol**
-  * [Authentication](./docs/REST/authentication.md)
+  * [Authentication](./docs/REST/authentication/index.md)
+  * [Authorization](./docs/REST/authorization/index.md)
   * [Consistency Model](./docs/REST/consistency.md)
   * [Common Headers](./docs/REST/headers.md)
   * [Throttling](./docs/REST/throttling.md)

--- a/docs/REST/authentication/aad.md
+++ b/docs/REST/authentication/aad.md
@@ -1,0 +1,57 @@
+# Azure Active Directory Authentication - REST API Reference
+
+HTTP requests may be authenticated using the **Bearer** authentication scheme with a token acquired from Azure Active Directory (AAD). These requests must be transmitted over TLS. 
+
+*Prerequisites*: 
+- The principal that will be used to request an AAD token must be assigned to one of the applicable [App Configuration roles](../authorization/aad.md)
+
+Provide each request with all HTTP headers required for Authentication. The minimum required are:
+
+|  Request Header | Description  |
+| --------------- | ------------ |
+| **Authorization** | Authentication information required by **Bearer** scheme. Format and details are explained below. |
+
+
+**Example:**
+```
+Host: {myconfig}.azconfig.io
+Authorization: Bearer {{AadToken}}
+```
+
+
+## Azure Active Directory Token Acquisition
+
+Before acquiring an AAD token one must identify what user they want to authenticate as, what audience they are requesting the token for, and what AAD endpoint (authority) they should use.
+
+**Audience**
+
+The AAD token must be requested with a proper audience. For Azure App Configuration one of the following audiences should be specified when requesting a token. The audience may also be referred to as the "resource" that the token is being requested for.
+
+ - {configurationStoreName}.azconfig.io
+ - *.azconfig.io
+
+**Important:** When the audience requested is {configurationStoreName}.azconfig.io, it must exactly match the "Host" request header (case sensitive) used to send the request.
+
+**AAD Authority** 
+
+The AAD authority is the endpoint that is used for acquiring an AAD token. It is in the form of `https://login.microsoftonline.com/{tenantId}`. The `{tenantId}` segement refers to the Azure Active Directory tenant id to which the user/application who is trying to authenticate belongs.
+
+**Authentication Libraries**
+
+Azure provides a set of libraries called Azure Active Directory Authentication Libraries (ADAL) to simplify the process of acquiring an AAD token. These libraries are built for multiple languages. Documentation can be found [here](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-authentication-libraries).
+
+## **Errors**
+
+```sh
+HTTP/1.1 401 Unauthorized
+WWW-Authenticate: HMAC-SHA256, Bearer
+```
+**Reason:** Authorization request header with Bearer scheme is not provided.
+**Solution:** Provide valid ```Authorization``` HTTP request header
+
+```sh
+HTTP/1.1 401 Unauthorized
+WWW-Authenticate: HMAC-SHA256, Bearer error="invalid_token", error_description="Authorization token failed validation"
+```
+**Reason:** The AAD token is not valid.
+**Solution:** Acquire an AAD token from the AAD Authority and ensure the proper audience is used.

--- a/docs/REST/authentication/hmac.md
+++ b/docs/REST/authentication/hmac.md
@@ -1,6 +1,6 @@
-﻿# Authentication - REST API Reference
+# HMAC Authentication - REST API Reference
 #
-All HTTP requests must be authenticated using the **HMAC-SHA256** authentication scheme and transmitted over TLS. 
+HTTP requests may be authenticated using the **HMAC-SHA256** authentication scheme. These requests must be transmitted over TLS. 
 
 *Prerequisites*: 
 - **Credential** - \<Access Key ID\>
@@ -92,7 +92,7 @@ _String-To-Sign=_
 string-To-Sign=
             "GET" + '\n' +                                                                                      // VERB
             "/kv?fields=*" + '\n' +                                                                             // path_and_query
-            "Fri, 11 May 2018 18:48:36 GMT;{myconfig}.azconfig.io;47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU="    // signed_headers_values
+            "Fri, 11 May 2018 18:48:36 GMT;example.azconfig.io;47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU="    // signed_headers_values
 ```
 
 #
@@ -103,7 +103,7 @@ string-To-Sign=
 
 ```sh
 HTTP/1.1 401 Unauthorized
-WWW-Authenticate: HMAC-SHA256
+WWW-Authenticate: HMAC-SHA256, Bearer
 ```
 **Reason:** Authorization request header with HMAC-SHA256 scheme is not provided.
 **Solution:** Provide valid ```Authorization``` HTTP request header
@@ -112,7 +112,7 @@ WWW-Authenticate: HMAC-SHA256
 #
 ```sh
 HTTP/1.1 401 Unauthorized
-WWW-Authenticate: HMAC-SHA256 error="invalid_token" error_description="The access token has expired"
+WWW-Authenticate: HMAC-SHA256 error="invalid_token" error_description="The access token has expired", Bearer
 ```
 **Reason:** ```Date``` or ```x-ms-date``` request header is more than 15 minutes off from the current GMT time.
 **Solution:** Provide correct date and time
@@ -121,7 +121,7 @@ WWW-Authenticate: HMAC-SHA256 error="invalid_token" error_description="The acces
 #
 ```sh
 HTTP/1.1 401 Unauthorized
-WWW-Authenticate: HMAC-SHA256 error="invalid_token" error_description="Invalid access token date"
+WWW-Authenticate: HMAC-SHA256 error="invalid_token" error_description="Invalid access token date", Bearer
 ```
 **Reason:** Missing or invalid ```Date``` or ```x-ms-date``` request header
 #
@@ -129,7 +129,7 @@ WWW-Authenticate: HMAC-SHA256 error="invalid_token" error_description="Invalid a
 #
 ```sh
 HTTP/1.1 401 Unauthorized
-WWW-Authenticate: HMAC-SHA256 error="invalid_token" error_description="[Credential][SignedHeaders][Signature] is required"
+WWW-Authenticate: HMAC-SHA256 error="invalid_token" error_description="[Credential][SignedHeaders][Signature] is required", Bearer
 ```
 **Reason:** Missing a required parameter from ```Authorization``` request header
 #
@@ -137,7 +137,7 @@ WWW-Authenticate: HMAC-SHA256 error="invalid_token" error_description="[Credenti
 #
 ```sh
 HTTP/1.1 401 Unauthorized
-WWW-Authenticate: HMAC-SHA256 error="invalid_token" error_description="Invalid Credential"
+WWW-Authenticate: HMAC-SHA256 error="invalid_token" error_description="Invalid Credential", Bearer
 ```
 **Reason:** Provided [```Host```]/[Access Key ID] is not found.
 **Solution:** Check the ```Credential``` parameter of the ```Authorization``` request header and make sure it is a valid Access Key ID. Make sure the ```Host``` header points to the registered account.
@@ -146,7 +146,7 @@ WWW-Authenticate: HMAC-SHA256 error="invalid_token" error_description="Invalid C
 #
 ```sh
 HTTP/1.1 401 Unauthorized
-WWW-Authenticate: HMAC-SHA256 error="invalid_token" error_description="Invalid Signature"
+WWW-Authenticate: HMAC-SHA256 error="invalid_token" error_description="Invalid Signature", Bearer
 ```
 **Reason:** The ```Signature``` provided doesn't match what the server expects.
 **Solution:** Make sure the ```String-To-Sign``` is correct. Make sure the ```Secret``` is correct and properly used (base64 decoded prior to using). See **Examples** section.
@@ -155,7 +155,7 @@ WWW-Authenticate: HMAC-SHA256 error="invalid_token" error_description="Invalid S
 #
 ```sh
 HTTP/1.1 401 Unauthorized
-WWW-Authenticate: HMAC-SHA256 error="invalid_token" error_description="Signed request header 'xxx' is not provided"
+WWW-Authenticate: HMAC-SHA256 error="invalid_token" error_description="Signed request header 'xxx' is not provided", Bearer
 ```
 **Reason:** Missing request header required by ```SignedHeaders``` parameter in ```Authorization``` header.
 **Solution:** Provide the required header with correct value.
@@ -164,7 +164,7 @@ WWW-Authenticate: HMAC-SHA256 error="invalid_token" error_description="Signed re
 #
 ```sh
 HTTP/1.1 401 Unauthorized
-WWW-Authenticate: HMAC-SHA256 error="invalid_token" error_description="XXX is required as a signed header"
+WWW-Authenticate: HMAC-SHA256 error="invalid_token" error_description="XXX is required as a signed header", Bearer
 ```
 **Reason:** Missing parameter in ```SignedHeaders```.
 **Solution:** Check **Signed Headers** minimum requirements.

--- a/docs/REST/authentication/index.md
+++ b/docs/REST/authentication/index.md
@@ -4,8 +4,8 @@ All HTTP requests must be authenticated. The following authentication schemes ar
 
 ## HMAC
 
-[HMAC authentication](./authentication/hmac.md) uses a randomly generated secret to sign request payloads. Details on how requests using this authentication method are authorized can be found in the [HMAC authorization](../authorization/hmac.md) section.
+[HMAC authentication](./hmac.md) uses a randomly generated secret to sign request payloads. Details on how requests using this authentication method are authorized can be found in the [HMAC authorization](../authorization/hmac.md) section.
 
 ## Azure Active Directory
 
-[Azure Active Directory (AAD) authentication](./authentication/aad.md) utilizes a bearer token that is obtained from Azure Active Directory to authenticate requests. Details on how requests using this authentication method are authorized can be found in the [AAD authorization](../authorization/aad.md) section.
+[Azure Active Directory (AAD) authentication](./aad.md) utilizes a bearer token that is obtained from Azure Active Directory to authenticate requests. Details on how requests using this authentication method are authorized can be found in the [AAD authorization](../authorization/aad.md) section.

--- a/docs/REST/authentication/index.md
+++ b/docs/REST/authentication/index.md
@@ -1,0 +1,11 @@
+﻿# Authentication
+
+All HTTP requests must be authenticated. The following authentication schemes are supported.
+
+## HMAC
+
+[HMAC authentication](./authentication/hmac.md) uses a randomly generated secret to sign request payloads. Details on how requests using this authentication method are authorized can be found in the [HMAC authorization](../authorization/hmac.md) section.
+
+## Azure Active Directory
+
+[Azure Active Directory (AAD) authentication](./authentication/aad.md) utilizes a bearer token that is obtained from Azure Active Directory to authenticate requests. Details on how requests using this authentication method are authorized can be found in the [AAD authorization](../authorization/aad.md) section.

--- a/docs/REST/authorization/aad.md
+++ b/docs/REST/authorization/aad.md
@@ -1,0 +1,43 @@
+# Azure Active Directory Authorization - REST API Reference
+
+When Azure Active Directory (AAD) authentication is used, authorization is handled by Azure Role Based Access Control (RBAC). Azure RBAC requires users to be assigned to roles in order to grant access to resources. Each role contains a set of actions that users assigned to the role will be able to perform.
+
+## Roles
+
+There following roles are built-in roles that are available in Azure subscriptions by default.
+
+### Azure App Configuration Data Owner
+
+This role provides full access to all operations.
+
+### Azure App Configuration Data Reader
+
+This role enables read operations.
+
+## Actions
+
+Roles contain a list of actions that users assigned to that role can perform. Azure App Configuration supports the following actions.
+
+### Microsoft.AppConfiguration/configurationStores/keyValues/read
+
+This action allows read access to App Configuration key-value resources such as /kv and /labels.
+
+### Microsoft.AppConfiguration/configurationStores/keyValues/write
+
+This action allows write access to App Configuration key-value resources.
+
+### Microsoft.AppConfiguration/configurationStores/keyValues/delete
+
+This action allows App Configuration key-value resources to be deleted. Note, deleting a resource returns the key-value that was deleted.
+
+## Errors
+
+```sh
+HTTP/1.1 403 Forbidden
+```
+**Reason:** The principal making the request does not have the required permissions to perform the requested operation.
+**Solution:** Assign the role required to perform the requested operation to the principal making the request.
+
+## Managing Role Assignments
+
+Managing role assignments is done using [Azure RBAC](https://docs.microsoft.com/en-us/azure/role-based-access-control/overview) procedures that are standard across all Azure services. It is possible to do this through Azure CLI, PowerShell, the Azure Portal, and more. Official documentation on how to make role assignments can be found [here](https://docs.microsoft.com/en-us/azure/role-based-access-control/role-assignments-portal).

--- a/docs/REST/authorization/hmac.md
+++ b/docs/REST/authorization/hmac.md
@@ -1,6 +1,6 @@
 # HMAC Authorization - REST API Reference
 
-When HMAC authentication is used, operations fall in to one of two categories, read or write. Read-write access keys grant permission to call all operations. Read-only access keys grant permission to call only read operations. Whether an access key is read only or read-write is determined by its `readOnly` property. Any attempt to make a write request with a read only access key will result in the request being unauthorized.
+When HMAC authentication is used, operations fall in to one of two categories, read or write. Read-write access keys grant permission to call all operations. Read-only access keys grant permission to call only read operations. Whether an access key is read-only or read-write is determined by its `readOnly` property. Any attempt to make a write request with a read-only access key will result in the request being unauthorized.
 
 The specification describing access keys and the API used to obtain them is detailed in the Azure App Configuration resource provider spec [here](https://github.com/Azure/azure-rest-api-specs/blob/master/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/stable/2019-10-01/appconfiguration.json). Access keys are obtained via the "ConfigurationStores_ListKeys" operation.
 

--- a/docs/REST/authorization/hmac.md
+++ b/docs/REST/authorization/hmac.md
@@ -1,0 +1,13 @@
+# HMAC Authorization - REST API Reference
+
+When HMAC authentication is used, operations fall in to one of two categories, read or write. Read-write access keys grant permission to call all operations. Read-only access keys grant permission to call only read operations. Whether an access key is read only or read-write is determined by its `readOnly` property. Any attempt to make a write request with a read only access key will result in the request being unauthorized.
+
+The specification describing access keys and the API used to obtain them is detailed in the Azure App Configuration resource provider spec [here](https://github.com/Azure/azure-rest-api-specs/blob/master/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/stable/2019-10-01/appconfiguration.json). Access keys are obtained via the "ConfigurationStores_ListKeys" operation.
+
+## Errors
+
+```sh
+HTTP/1.1 403 Forbidden
+```
+**Reason:** The access key used to authenticate the request does not provide the required permissions to perform the requested operation.
+**Solution:** Obtain an access key that provides permission to perform the requested operation and use it to authenticate the request.

--- a/docs/REST/authorization/index.md
+++ b/docs/REST/authorization/index.md
@@ -1,0 +1,11 @@
+﻿# Authorization
+
+Authorization refers to the procedure used to determine the permissions that a caller has when making a request. There are multiple authorization models. The authorization model that is used for a request depends on the [authentication](../authentication/index.md) method that is used. The authorization models are listed below.
+
+## HMAC
+
+The [authorization model](./hmac.md) model associated with HMAC authentication splits permissions into read-only or read-write. See the [HMAC authorization](./hmac.md) page for details.
+
+## Azure Active Directory
+
+The [authorization model](./aad.md) associated with Azure Active Directory (AAD) authentication uses Azure RBAC to control permissions. See the [AAD authorization](./aad.md) page for details.

--- a/docs/REST/fiddler.md
+++ b/docs/REST/fiddler.md
@@ -1,6 +1,6 @@
 ﻿# Fiddler Configuration - REST API Reference
 #
-To test the REST API using [Fiddler](https://www.telerik.com/fiddler), requests need to include the headers required for [authentication](./authentication.md). Here's how to configure Fiddler for testing the REST API, generating the authentication headers automatically:
+To test the REST API using [Fiddler](https://www.telerik.com/fiddler), requests need to include the headers required for [authentication](./authentication/hmac.md). Here's how to configure Fiddler for testing the REST API, generating the authentication headers automatically:
 
 1. Ensure that TLS 1.2 is an allowed protocol
 

--- a/docs/REST/headers.md
+++ b/docs/REST/headers.md
@@ -7,18 +7,18 @@ The following table describes common request headers used in Azure App Configura
 
 | Header | Description | Example |
 | -- | -- | -- |
-| **Authorization** | Used to [authenticate](./authentication.md) a request to the service. See [section 14.8](https://tools.ietf.org/html/rfc2616#section-14.8) | `Authorization: HMAC-SHA256 Credential=<Credential>&SignedHeaders=Host;x-ms-date;x-ms-content-sha256&Signature=<Signature>` |
+| **Authorization** | Used to [authenticate](./authentication/index.md) a request to the service. See [section 14.8](https://tools.ietf.org/html/rfc2616#section-14.8) | `Authorization: HMAC-SHA256 Credential=<Credential>&SignedHeaders=Host;x-ms-date;x-ms-content-sha256&Signature=<Signature>` |
 | **Accept** | Informs the server what media type the client will accept in an HTTP response. See [section 14.1](https://tools.ietf.org/html/rfc2616#section-14.1) | `Accept: application/vnd.microsoft.appconfig.kv+json;` |
 | **Accept-Datetime** | Requests the server to return its content as a representation of its prior state. The value of this header is the requested datetime of that state. See [RFC 7089](https://tools.ietf.org/html/rfc7089#section-2.1.1) | `Accept-Datetime: Sat, 12 May 2018 02:10:00 GMT` |
 | **Content-Type** | Contains the media-type of the content within the HTTP request body. See [section 14.17](https://tools.ietf.org/html/rfc2616#section-14.17) | `Content-Type: application/vnd.microsoft.appconfig.kv+json; charset=utf-8;` |
-| **Date** | The datetime that the HTTP request was issued. This header is used in [authentication](./authentication.md). See [section 14.18](https://tools.ietf.org/html/rfc2616#section-14.18) | `Date: Fri, 11 May 2018 18:48:36 GMT` |
-| **Host** | Specifies the tenant for which the request has been issued. This header is used in [authentication](./authentication.md). See [section 14.23](https://tools.ietf.org/html/rfc2616#section-14.23) | `Host: contoso.azconfig.io` |
+| **Date** | The datetime that the HTTP request was issued. This header is used in [HMAC authentication](./authentication/hmac.md). See [section 14.18](https://tools.ietf.org/html/rfc2616#section-14.18) | `Date: Fri, 11 May 2018 18:48:36 GMT` |
+| **Host** | Specifies the tenant for which the request has been issued. This header is used in [HMAC authentication](./authentication/hmac.md). See [section 14.23](https://tools.ietf.org/html/rfc2616#section-14.23) | `Host: contoso.azconfig.io` |
 | **If-Match** | Used to make an HTTP request conditional. This request should only succeed if the targetted resource's etag matches the value of this header. The '*' value matches any etag. See [section 14.24](https://tools.ietf.org/html/rfc2616#section-14.24) | `If-Match: "4f6dd610dd5e4deebc7fbaef685fb903"` |
 | **If-None-Match** | Used to make an HTTP request conditional. This request should only succeed if the targetted resource's etag does not match the value of this header. The '*' value matches any etag. See [section 14.26](https://tools.ietf.org/html/rfc2616#section-14.26) | `If-None-Match: "4f6dd610dd5e4deebc7fbaef685fb903"` |
 | **Sync-Token** | Used to enable real-time consistency during a sequence of requests. | `Sync-Token: jtqGc1I4=MDoyOA==;sn=28` |
 | **x-ms-client-request-id** | A unique id provided by the client used to track a request's round-trip. | `x-ms-client-request-id: 00000000-0000-0000-0000-000000000000` |
-| **x-ms-content-sha256** | A sha256 digest of the HTTP request body. This header is used in [authentication](./authentication.md). | `x-ms-content-sha256: 47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=` |
-| **x-ms-date** | This header may be set and used in place of the `Date` header if the date header is unable to be accessed. This header is used in [authentication](./authentication.md). | `x-ms-date: Fri, 11 May 2018 18:48:36 GMT` |
+| **x-ms-content-sha256** | A sha256 digest of the HTTP request body. This header is used in [HMAC authentication](./authentication/hmac.md). | `x-ms-content-sha256: 47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=` |
+| **x-ms-date** | This header may be set and used in place of the `Date` header if the date header is unable to be accessed. This header is used in [HMAC authentication](./authentication/hmac.md). | `x-ms-date: Fri, 11 May 2018 18:48:36 GMT` |
 | **x-ms-return-client-request-id** | Used in conjunction with the `x-ms-client-request-id` header. If the value of this header is 'true' then the server will be instructed to return the value of the `x-ms-client-request-id` request header. | `x-ms-return-client-request-id: true` |
 
 ## Response Headers

--- a/docs/REST/keys.md
+++ b/docs/REST/keys.md
@@ -18,7 +18,7 @@ For all operations ``name`` is an optional filter parameter. If ommited it impli
 #
 #
 **Prerequisites**:
-- All HTTP requests must be authenticated. See the [authentication](./authentication.md) section.
+- All HTTP requests must be authenticated. See the [authentication](./authentication/index.md) section.
 - All HTTP requests must provide explicit ``api-version``. See the [versioning](./versioning.md) section.
 
 #

--- a/docs/REST/kv.md
+++ b/docs/REST/kv.md
@@ -15,7 +15,7 @@ Key-Value is a resource identified by unique combination of ``key`` + ``label``.
 #
 #
 **Prerequisites:** 
-- All HTTP requests must be authenticated. See the [authentication](./authentication.md) section.
+- All HTTP requests must be authenticated. See the [authentication](./authentication/index.md) section.
 - All HTTP requests must provide explicit ``api-version``. See the [versioning](./versioning.md) section.
 
 #

--- a/docs/REST/labels.md
+++ b/docs/REST/labels.md
@@ -18,7 +18,7 @@ For all operations ``name`` is an optional filter parameter. If ommited it impli
 #
 #
 **Prerequisites**: 
-- All HTTP requests must be authenticated. See the [authentication](./authentication.md) section.
+- All HTTP requests must be authenticated. See the [authentication](./authentication/index.md) section.
 - All HTTP requests must provide explicit ``api-version``. See the [versioning](./versioning.md) section.
 #
 #

--- a/docs/REST/locks.md
+++ b/docs/REST/locks.md
@@ -12,7 +12,7 @@ If present, ``label`` must be an explcit label value (**not** a wildcard). For a
 #
 #
 **Prerequisites**: 
-- All HTTP requests must be authenticated. See the [authentication](./authentication.md) section.
+- All HTTP requests must be authenticated. See the [authentication](./authentication/index.md) section.
 - All HTTP requests must provide explicit ``api-version``. See the [versioning](./versioning.md) section.
 
 #

--- a/docs/REST/postman.md
+++ b/docs/REST/postman.md
@@ -1,10 +1,10 @@
 ﻿# Postman Configuration - REST API Reference
 #
-To test the REST API using [Postman](https://www.getpostman.com/), requests need to include the headers required for [authentication](./authentication.md). Here's how to configure Postman for testing the REST API, generating the authentication headers automatically:
+To test the REST API using [Postman](https://www.getpostman.com/), requests need to include the headers required for [authentication](./authentication/hmac.md). Here's how to configure Postman for testing the REST API, generating the authentication headers automatically:
 
 1. Create a new [request](https://learning.getpostman.com/docs/postman/sending_api_requests/requests/)
 
-2. Add the `signRequest` function from the [JavaScript authentication sample](./authentication.md#JavaScript) to the [pre-request script](https://learning.getpostman.com/docs/postman/scripts/pre_request_scripts/) for the request
+2. Add the `signRequest` function from the [JavaScript authentication sample](./authentication/hmac.md#JavaScript) to the [pre-request script](https://learning.getpostman.com/docs/postman/scripts/pre_request_scripts/) for the request
 
 3. Add the following code to the end of the pre-request script and update the access key as indicated by the TODO comment
 

--- a/docs/REST/revisions.md
+++ b/docs/REST/revisions.md
@@ -13,7 +13,7 @@ For all operations ``label`` is an optional parameter. If ommited it implies **a
 #
 #
 **Prerequisites**: 
-- All HTTP requests must be authenticated. See the [authentication](./authentication.md) section.
+- All HTTP requests must be authenticated. See the [authentication](./authentication/index.md) section.
 - All HTTP requests must provide explicit ``api-version``. See the [versioning](./versioning.md) section.
 
 #


### PR DESCRIPTION
This PR adds protocol documentation for AAD authentication and authorization. It also establishes a new pattern for documenting authentication vs authorization. This is handled by having a separate authentication and authorization folder. Authentication links have been updated to point to either the authentication index page or the relevant authentication scheme page.

The content of this doc set has already been reviewed internally, but feel free to give another go at reviewing the content.