### PR TITLE
Enhanced feature management release notes for 2.0 to mention cache changes and side effects.

### DIFF
--- a/releaseNotes/Microsoft.Featuremanagement.md
+++ b/releaseNotes/Microsoft.Featuremanagement.md
@@ -61,7 +61,7 @@ With the introduction of `IContextualFeatureFilter` there are now two types of f
 
 **Feature Settings Cache**
 
-Caching has been added to respect the reload token of the .NET Core configuration system. If a configuration provider is used that does not properly trigger the reload token of the .NET Core configuration system, `FeatureManager` will not be able to pickup changes.
+A cache for feature settings has been added which respects the reload token of the .NET Core configuration system. If a configuration provider is used that does not properly trigger the reload token of the .NET Core configuration system, `FeatureManager` will not be able to pickup changes.
 
 ### Breaking Changes
 * `IFeatureManager.IsEnabled` is now asynchronous

--- a/releaseNotes/Microsoft.Featuremanagement.md
+++ b/releaseNotes/Microsoft.Featuremanagement.md
@@ -59,7 +59,7 @@ As an example, `IContextualFeatureFilter<IAccountContext>` requires a context th
 
 With the introduction of `IContextualFeatureFilter` there are now two types of feature filters including `IFeatureFilter`. The two types of feature filters both inherit `IFeatureFilterMetadata`. `IFeatureFilterMetadata` is a marker interface and does not actually provide any feature filtering capabilities. It is used as the new parameter type for `IFeatureManagementBuilder.AddFeatureFilter`.
 
-**Feature Settings Cache**
+**Performance Improvement**
 
 A cache for feature settings has been added which respects the reload token of the .NET Core configuration system. If a configuration provider is used that does not properly trigger the reload token of the .NET Core configuration system, `FeatureManager` will not be able to pickup changes.
 

--- a/releaseNotes/Microsoft.Featuremanagement.md
+++ b/releaseNotes/Microsoft.Featuremanagement.md
@@ -59,6 +59,10 @@ As an example, `IContextualFeatureFilter<IAccountContext>` requires a context th
 
 With the introduction of `IContextualFeatureFilter` there are now two types of feature filters including `IFeatureFilter`. The two types of feature filters both inherit `IFeatureFilterMetadata`. `IFeatureFilterMetadata` is a marker interface and does not actually provide any feature filtering capabilities. It is used as the new parameter type for `IFeatureManagementBuilder.AddFeatureFilter`.
 
+**Feature Settings Cache**
+
+Caching has been added to respect the reload token of the .NET Core configuration system. If a configuration provider is used that does not properly trigger the reload token of the .NET Core configuration system, `FeatureManager` will not be able to pickup changes.
+
 ### Breaking Changes
 * `IFeatureManager.IsEnabled` is now asynchronous
   * `IsEnabled` was renamed to `IsEnabledAsync`.


### PR DESCRIPTION
A user reported experiencing an issue when migrating to 2.0 of the Microsoft.FeatureManagement library. This was due to a new caching strategy added in the library on the latest release. It is worth mentioning this optimization and its side effects in the release notes.