### PR TITLE
Add release note for vstsTask 3.0.13

### DIFF
--- a/releaseNotes/AzureDevOpsPipelineExtension.md
+++ b/releaseNotes/AzureDevOpsPipelineExtension.md
@@ -5,7 +5,7 @@ The Azure App Configuration extension in Azure DevOps pipeline has been publishe
 ![sample](pictures/AzureDevOpsExtensionVersionSample.PNG)
 
 ### v3.0.13 - May, 04 2020
-* Fixed the issue that some reserved symbols misencoded set to environment variables. [#313](https://github.com/Azure/AppConfiguration/issues/313)
+* Fixed the issue that some symbols, for example, percent sign (%), could not be set to Pipeline Task variables correctly. [#313](https://github.com/Azure/AppConfiguration/issues/313)
 
 ### v2.0.11 - March, 24 2020
 * The Azure App Configuration pipeline task for the Azure DevOps is now generally available.

--- a/releaseNotes/AzureDevOpsPipelineExtension.md
+++ b/releaseNotes/AzureDevOpsPipelineExtension.md
@@ -4,7 +4,8 @@ The Azure App Configuration extension in Azure DevOps pipeline has been publishe
 
 ![sample](pictures/AzureDevOpsExtensionVersionSample.PNG)
 
-### v3.0.13
+### v3.0.13 - May, 04 2020
+* Fixed the issue that some reserved symbols misencoded set to environment variables. [#313](https://github.com/Azure/AppConfiguration/issues/313)
 
 ### v2.0.11 - March, 24 2020
 * The Azure App Configuration pipeline task for the Azure DevOps is now generally available.

--- a/releaseNotes/AzureDevOpsPipelineExtension.md
+++ b/releaseNotes/AzureDevOpsPipelineExtension.md
@@ -4,6 +4,8 @@ The Azure App Configuration extension in Azure DevOps pipeline has been publishe
 
 ![sample](pictures/AzureDevOpsExtensionVersionSample.PNG)
 
+### v3.0.13
+
 ### v2.0.11 - March, 24 2020
 * The Azure App Configuration pipeline task for the Azure DevOps is now generally available.
 * Added `FAQ` section to the [documentation](https://marketplace.visualstudio.com/items?itemName=AzureAppConfiguration.azure-app-configuration-task).  


### PR DESCRIPTION
* The latest release removed the deployment of `pipeline-task-lib` to bypass misencoded symbol issue.