### PR TITLE
Add release notes for configuration provider v4.0.0-preview

### DIFF
--- a/releaseNotes/MicrosoftAzureAppConfigurationAspNetCore.md
+++ b/releaseNotes/MicrosoftAzureAppConfigurationAspNetCore.md
@@ -3,9 +3,12 @@
 
 ### 4.0.0-preview - July 23, 2020
 * Added multi-targeting support for .NET Core 3.1 besides .NET Standard 2.0. [#173](https://github.com/Azure/AppConfiguration-DotnetProvider/issues/173)
-* Extracted out the code to retrieve required dependencies for configuration refresh from `IApplicationBuilder.UseAzureAppConfiguration()` to `IServiceCollection.AddAzureAppConfiguration()` in the package `Microsoft.Extensions.Configuration.AzureAppConfiguration`, so it could be re-used for non ASP.NET Core applications.
-    * Users must call `IServiceCollection.AddAzureAppConfiguration()` to register the required services for configuration refresh before they can call `IApplicationBuilder.UseAzureAppConfiguration()`.
+
+* Updated code to leverage the new feature of dependency injection support for obtaining `IConfigurationRefresher` instances introduced in the `4.0.0-preview` version of the `Microsoft.Extensions.Configuration.AzureAppConfiguration` package.
+    * Users must call `IServiceCollection.AddAzureAppConfiguration()` in `ConfigureServices(...)` to register the required services for configuration refresh before they can call `IApplicationBuilder.UseAzureAppConfiguration()`. This makes it easier to retrieve instances of `IConfigurationRefresher` through dependency injection in a controller or a middleware, and have better control of when and how configuration is refreshed.
+
     * An exception is thrown when the required services for configuration refresh could not be retrieved from the `IServiceCollection` instance. [#166](https://github.com/Azure/AppConfiguration-DotnetProvider/issues/166)
+
 * Updated `Microsoft.Extensions.Configuration.AzureAppConfiguration` reference to `4.0.0-preview`. See the [release notes](./MicrosoftExtensionsConfigurationAzureAppConfiguration.md) for more information on the changes.
 
 ### 3.0.2 - July 01, 2020

--- a/releaseNotes/MicrosoftAzureAppConfigurationAspNetCore.md
+++ b/releaseNotes/MicrosoftAzureAppConfigurationAspNetCore.md
@@ -2,7 +2,10 @@
 ### [Package (NuGet)](https://www.nuget.org/packages/Microsoft.Azure.AppConfiguration.AspNetCore)
 
 ### 4.0.0-preview - July 23, 2020
-* Added multi-targeting support for .NET Core 3.1. [#173](https://github.com/Azure/AppConfiguration-DotnetProvider/issues/173)
+* Added multi-targeting support for .NET Core 3.1 besides .NET Standard 2.0. [#173](https://github.com/Azure/AppConfiguration-DotnetProvider/issues/173)
+* Extracted out the code to retrieve required dependencies for configuration refresh from `IApplicationBuilder.UseAzureAppConfiguration()` to `IServiceCollection.AddAzureAppConfiguration()` in the package `Microsoft.Extensions.Configuration.AzureAppConfiguration`, so it could be re-used for non ASP.NET Core applications.
+    * Users must call `IServiceCollection.AddAzureAppConfiguration()` to register the required services for configuration refresh before they can call `IApplicationBuilder.UseAzureAppConfiguration()`.
+    * An exception is thrown when the required services for configuration refresh could not be retrieved from the `IServiceCollection` instance. [#166](https://github.com/Azure/AppConfiguration-DotnetProvider/issues/166)
 * Updated `Microsoft.Extensions.Configuration.AzureAppConfiguration` reference to `4.0.0-preview`. See the [release notes](./MicrosoftExtensionsConfigurationAzureAppConfiguration.md) for more information on the changes.
 
 ### 3.0.2 - July 01, 2020

--- a/releaseNotes/MicrosoftAzureAppConfigurationAspNetCore.md
+++ b/releaseNotes/MicrosoftAzureAppConfigurationAspNetCore.md
@@ -4,12 +4,12 @@
 ### 4.0.0-preview - July 23, 2020
 * Added multi-targeting support for .NET Core 3.1 besides .NET Standard 2.0. [#173](https://github.com/Azure/AppConfiguration-DotnetProvider/issues/173)
 
-* Updated code to leverage the new feature of dependency injection support for obtaining `IConfigurationRefresher` instances introduced in the `4.0.0-preview` version of the `Microsoft.Extensions.Configuration.AzureAppConfiguration` package.
+* **Breaking Change :** To leverage the new feature of dependency injection support for obtaining `IConfigurationRefresher` instances introduced in the `4.0.0-preview` version of the `Microsoft.Extensions.Configuration.AzureAppConfiguration` package, the following changes are made.
     * Users must call `IServiceCollection.AddAzureAppConfiguration()` in `ConfigureServices(...)` to register the required services for configuration refresh before they can call `IApplicationBuilder.UseAzureAppConfiguration()`. This makes it easier to retrieve instances of `IConfigurationRefresher` through dependency injection in a controller or a middleware, and have better control of when and how configuration is refreshed.
 
     * An exception is thrown when the required services for configuration refresh could not be retrieved from the `IServiceCollection` instance. [#166](https://github.com/Azure/AppConfiguration-DotnetProvider/issues/166)
 
-* Updated `Microsoft.Extensions.Configuration.AzureAppConfiguration` reference to `4.0.0-preview`. See the [release notes](./MicrosoftExtensionsConfigurationAzureAppConfiguration.md) for more information on the changes.
+* **Breaking Change :** Updated `Microsoft.Extensions.Configuration.AzureAppConfiguration` reference to `4.0.0-preview`. See the [release notes](./MicrosoftExtensionsConfigurationAzureAppConfiguration.md) for more information on the changes.
 
 ### 3.0.2 - July 01, 2020
 * Updated `Microsoft.Extensions.Configuration.AzureAppConfiguration` reference to `3.0.2`. See the [release notes](./MicrosoftExtensionsConfigurationAzureAppConfiguration.md) for more information on the changes.

--- a/releaseNotes/MicrosoftAzureAppConfigurationAspNetCore.md
+++ b/releaseNotes/MicrosoftAzureAppConfigurationAspNetCore.md
@@ -1,6 +1,10 @@
 ## Microsoft.Azure.AppConfiguration.AspNetCore
 ### [Package (NuGet)](https://www.nuget.org/packages/Microsoft.Azure.AppConfiguration.AspNetCore)
 
+### 4.0.0-preview - July 23, 2020
+* Added multi-targeting support for .NET Core 3.1. [#173](https://github.com/Azure/AppConfiguration-DotnetProvider/issues/173)
+* Updated `Microsoft.Extensions.Configuration.AzureAppConfiguration` reference to `4.0.0-preview`. See the [release notes](./MicrosoftExtensionsConfigurationAzureAppConfiguration.md) for more information on the changes.
+
 ### 3.0.2 - July 01, 2020
 * Updated `Microsoft.Extensions.Configuration.AzureAppConfiguration` reference to `3.0.2`. See the [release notes](./MicrosoftExtensionsConfigurationAzureAppConfiguration.md) for more information on the changes.
 

--- a/releaseNotes/MicrosoftExtensionsConfigurationAzureAppConfiguration.md
+++ b/releaseNotes/MicrosoftExtensionsConfigurationAzureAppConfiguration.md
@@ -2,11 +2,15 @@
 ### [Package (NuGet)](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.AzureAppConfiguration)
 
 ### 4.0.0-preview - July 23, 2020
-* Added enhanced support for applications that leverage Event Grid integration in App Configuration for configuration refresh. The following new API is introduced in `IConfigurationRefresher` interface, which can be called when an application responds to push notifications from Event Grid. This signals the application to reassess whether configuration should be updated on the next call to `RefreshAsync()` or `TryRefreshAsync()`. [#133](https://github.com/Azure/AppConfiguration-DotnetProvider/issues/133)
+* **Breaking Change :** Added enhanced support for applications that leverage Event Grid integration in App Configuration for configuration refresh. The following new API is introduced in `IConfigurationRefresher` interface, which can be called when an application responds to push notifications from Event Grid. This signals the application to reassess whether configuration should be updated on the next call to `RefreshAsync()` or `TryRefreshAsync()`. [#133](https://github.com/Azure/AppConfiguration-DotnetProvider/issues/133)
    ````csharp
    void SetDirty(TimeSpan? maxDelay = null)
    ````
-* Added JSON content-type (e.g. MIME type `application/json`) support for key-values in App Configuration. This allows primitive types, arrays, and JSON objects to be loaded properly to `IConfiguration`. [#191](https://github.com/Azure/AppConfiguration-DotnetProvider/issues/191)
+* **Breaking Change :** Added JSON content-type (e.g. MIME type `application/json`) support for key-values in App Configuration. This allows primitive types, arrays, and JSON objects to be loaded properly to `IConfiguration`. Existing applications that use key-values with a valid JSON content-type may need to be updated. [#191](https://github.com/Azure/AppConfiguration-DotnetProvider/issues/191)
+* **Breaking Change :** Added the following property to `IConfigurationRefresher` to allow users to disambiguate instances of the interface when using multiple Azure App Configuration providers.
+   ````csharp
+   Uri AppConfigurationEndpoint { get; }
+   ````
 * Added support for applications to obtain `IConfigurationRefresher` instances through dependency injection (DI). This allows better control of when to call `RefreshAsync()/TryRefreshAsync()` or whether to `await` the call. The following two APIs can be used to take advantage of this feature. [#167](https://github.com/Azure/AppConfiguration-DotnetProvider/issues/167)
 
     * Call `IServiceCollection.AddAzureAppConfiguration()` first to add required services to the DI container.

--- a/releaseNotes/MicrosoftExtensionsConfigurationAzureAppConfiguration.md
+++ b/releaseNotes/MicrosoftExtensionsConfigurationAzureAppConfiguration.md
@@ -1,6 +1,14 @@
 ## Microsoft.Extensions.Configuration.AzureAppConfiguration
 ### [Package (NuGet)](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.AzureAppConfiguration)
 
+### 4.0.0-preview - July 23, 2020
+* Added `IConfigurationRefresher.SetDirty` method  to set the cached value for key-values registered for refresh as dirty. For users that use push notifications from event grid to receive configuration change updates, this allows the cached values to be revalidated on the next call to `RefreshAsync` or `TryRefreshAsync`.
+* Added support for deserializing configuration settings with JSON content type. [#191](https://github.com/Azure/AppConfiguration-DotnetProvider/issues/191)
+* Added an interface `IConfigurationRefresherProvider` to provide access to instances of `IConfigurationRefresher` through dependency injection. This can be configured by adding a call to the following extension method on the service collection. [#167](https://github.com/Azure/AppConfiguration-DotnetProvider/issues/167)
+   ```` csharp
+   public static IServiceCollection AddAzureAppConfiguration(this IServiceCollection services)
+   ````
+
 ### 3.0.2 - July 01, 2020
 * Fixed an issue that may cause configuration refresh to be ignored when the key registered to refresh all configuration has changed. [#178](https://github.com/Azure/AppConfiguration-DotnetProvider/issues/178)
 

--- a/releaseNotes/MicrosoftExtensionsConfigurationAzureAppConfiguration.md
+++ b/releaseNotes/MicrosoftExtensionsConfigurationAzureAppConfiguration.md
@@ -2,12 +2,24 @@
 ### [Package (NuGet)](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.AzureAppConfiguration)
 
 ### 4.0.0-preview - July 23, 2020
-* Added `IConfigurationRefresher.SetDirty` method  to set the cached value for key-values registered for refresh as dirty. For users that use push notifications from event grid to receive configuration change updates, this allows the cached values to be revalidated on the next call to `RefreshAsync` or `TryRefreshAsync`.
-* Added support for deserializing configuration settings with JSON content type. [#191](https://github.com/Azure/AppConfiguration-DotnetProvider/issues/191)
-* Added an interface `IConfigurationRefresherProvider` to provide access to instances of `IConfigurationRefresher` through dependency injection. This can be configured by adding a call to the following extension method on the service collection. [#167](https://github.com/Azure/AppConfiguration-DotnetProvider/issues/167)
-   ```` csharp
-   public static IServiceCollection AddAzureAppConfiguration(this IServiceCollection services)
+* Added enhanced support for applications that leverage Event Grid integration in App Configuration for configuration refresh. The following new API is introduced in `IConfigurationRefresher` interface, which can be called when an application responds to push notifications from Event Grid. This signals the application to reassess whether configuration should be updated on the next call to `RefreshAsync()` or `TryRefreshAsync()`. [#133](https://github.com/Azure/AppConfiguration-DotnetProvider/issues/133)
+   ````csharp
+   void SetDirty(TimeSpan? maxDelay = null)
    ````
+* Added JSON content-type (e.g. MIME type `application/json`) support for key-values in App Configuration. This allows primitive types, arrays, and JSON objects to be loaded properly to IConfiguration. [#191](https://github.com/Azure/AppConfiguration-DotnetProvider/issues/191)
+* Added support for applications to obtain `IConfigurationRefresher` instances through dependency injection (DI). This allows better control of when to call `RefreshAsync()/TryRefreshAsync()` or whether to `await` the call. The following two APIs can be used to take advantage of this feature. [#167](https://github.com/Azure/AppConfiguration-DotnetProvider/issues/167)
+
+    * Call `IServiceCollection.AddAzureAppConfiguration()` first to add required services to the DI container.
+      ````csharp
+      public static IServiceCollection AddAzureAppConfiguration(this IServiceCollection services)
+      ````
+    * Retrieve `IConfigurationRefresher` instances via `IConfigurationRefresherProvider` interface obtained through DI.
+      ````csharp
+      public interface IConfigurationRefresherProvider
+      {
+         IEnumerable<IConfigurationRefresher> Refreshers { get; }
+      }
+      ````
 
 ### 3.0.2 - July 01, 2020
 * Fixed an issue that may cause configuration refresh to be ignored when the key registered to refresh all configuration has changed. [#178](https://github.com/Azure/AppConfiguration-DotnetProvider/issues/178)

--- a/releaseNotes/MicrosoftExtensionsConfigurationAzureAppConfiguration.md
+++ b/releaseNotes/MicrosoftExtensionsConfigurationAzureAppConfiguration.md
@@ -6,7 +6,7 @@
    ````csharp
    void SetDirty(TimeSpan? maxDelay = null)
    ````
-* Added JSON content-type (e.g. MIME type `application/json`) support for key-values in App Configuration. This allows primitive types, arrays, and JSON objects to be loaded properly to IConfiguration. [#191](https://github.com/Azure/AppConfiguration-DotnetProvider/issues/191)
+* Added JSON content-type (e.g. MIME type `application/json`) support for key-values in App Configuration. This allows primitive types, arrays, and JSON objects to be loaded properly to `IConfiguration`. [#191](https://github.com/Azure/AppConfiguration-DotnetProvider/issues/191)
 * Added support for applications to obtain `IConfigurationRefresher` instances through dependency injection (DI). This allows better control of when to call `RefreshAsync()/TryRefreshAsync()` or whether to `await` the call. The following two APIs can be used to take advantage of this feature. [#167](https://github.com/Azure/AppConfiguration-DotnetProvider/issues/167)
 
     * Call `IServiceCollection.AddAzureAppConfiguration()` first to add required services to the DI container.


### PR DESCRIPTION
This pull request adds the release notes for the .NET Configuration Provider v4.0.0-preview.
https://www.nuget.org/packages/Microsoft.Extensions.Configuration.AzureAppConfiguration/4.0.0-preview
https://www.nuget.org/packages/Microsoft.Azure.AppConfiguration.AspNetCore/4.0.0-preview