### PR TITLE
Update hmac.md for signing request using react native

### DIFF
--- a/docs/REST/authentication/hmac.md
+++ b/docs/REST/authentication/hmac.md
@@ -217,12 +217,12 @@ function signRequest(host,
 }
 ```
 
-### React native - Javacript
+### React native
 *Prerequisites*: [RNSimpleCrypto](https://github.com/ghbutton/react-native-simple-crypto), [base64](https://github.com/eranbo/react-native-base64)
 
 ```js
 const signRequest = async (
-  host,             // sample '<xconfig>.azconfig.io'
+  host,             // sample '<config>.azconfig.io'
   method = 'GET',   // GET, PUT, POST, DELETE
   url = '/kv?api-version=1.0',  // path+query
   body = undefined, // request body (undefined of none)


### PR DESCRIPTION
This PR will introduce a way for react native apps to utilize azure app configuration using REST with hmac signing.
Updated the hmac.md file to use crypto and base64 to get the relevant http headers and fetch app config or perform any other operation.