### PR TITLE
Update the Azure Functions example to use AppConfig as a config source

### DIFF
--- a/examples/DotNetCore/AzureFunction/FunctionApp/FunctionApp.csproj
+++ b/examples/DotNetCore/AzureFunction/FunctionApp/FunctionApp.csproj
@@ -4,10 +4,10 @@
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="3.0.0" />
-    <PackageReference Include="Microsoft.FeatureManagement" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="4.1.0" />
+    <PackageReference Include="Microsoft.FeatureManagement" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.11" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/examples/DotNetCore/AzureFunction/FunctionApp/Settings.cs
+++ b/examples/DotNetCore/AzureFunction/FunctionApp/Settings.cs
@@ -1,7 +1,0 @@
-﻿namespace FunctionApp
-{
-    public class Settings
-    {
-        public string Message { get; set; }
-    }
-}

--- a/examples/DotNetCore/AzureFunction/FunctionApp/ShowBetaFeature.cs
+++ b/examples/DotNetCore/AzureFunction/FunctionApp/ShowBetaFeature.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -14,10 +15,10 @@ namespace FunctionApp
         private readonly IFeatureManagerSnapshot _featureManagerSnapshot;
         private readonly IConfigurationRefresher _configurationRefresher;
 
-        public ShowBetaFeature(IFeatureManagerSnapshot featureManagerSnapshot, IConfigurationRefresher configurationRefresher)
+        public ShowBetaFeature(IFeatureManagerSnapshot featureManagerSnapshot, IConfigurationRefresherProvider refresherProvider)
         {
             _featureManagerSnapshot = featureManagerSnapshot;
-            _configurationRefresher = configurationRefresher;
+            _configurationRefresher = refresherProvider.Refreshers.First();
         }
 
         [FunctionName("ShowBetaFeature")]

--- a/examples/DotNetCore/AzureFunction/FunctionApp/Startup.cs
+++ b/examples/DotNetCore/AzureFunction/FunctionApp/Startup.cs
@@ -24,8 +24,6 @@ namespace FunctionApp
                        // Indicate to load feature flags
                        .UseFeatureFlags();
             });
-
-            base.ConfigureAppConfiguration(builder);
         }
 
         public override void Configure(IFunctionsHostBuilder builder)


### PR DESCRIPTION
- By taking advantage of the Azure Functions `IFunctionsConfigurationBuilder`, the AppConfig provider can now be added as an additional config source. The Azure Functions existing providers will be preserved. 
  ![image](https://user-images.githubusercontent.com/10566826/103613421-62f59c80-4edb-11eb-8dae-e9a6d84374dd.png)
- Removed the use of strong type `Settings` and `IOptionsSnapshot` for simplicity. Technically, it's not an AppConfig specific usage pattern. Now that the AppConfig is just one of the providers, users can always do it if it's desired.
- Used the latest API in the config provider v4.1.0 to obtain the refresher instance from the DI
- Updated all dependencies to the latest version 