### PR TITLE
Add JSON Schema for `appconfig/kvset` profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ bld/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/
+
+# visual studio code
+.vscode/
+
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-    "markdownlint.config": {
-        "MD028": false,
-        "MD025": {
-            "front_matter_title": ""
-        }
-    }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "markdownlint.config": {
+        "MD028": false,
+        "MD025": {
+            "front_matter_title": ""
+        }
+    }
+}

--- a/docs/KVSet/KVSet.v1.0.0.schema.json
+++ b/docs/KVSet/KVSet.v1.0.0.schema.json
@@ -20,14 +20,14 @@
   "$defs": {
     "kv": {
       "type": "object",
-      "title": "Key value pair",
-      "description": "An individual key-value pair and associated metadata in the 'appconfig/kvset' format.",
+      "title": "Key-value",
+      "description": "An individual key-value and associated metadata in the 'appconfig/kvset' format.",
       "properties": {
         "key": {
           "$id": "#/properties/key",
           "type": "string",
           "title": "Key",
-          "description": "The 'key' in the key-value pair.",
+          "description": "The 'key' in the key-value.",
           "examples": [
             "background_color"
           ],
@@ -38,7 +38,7 @@
           "$id": "#/properties/value",
           "type": "string",
           "title": "Value",
-          "description": "The 'value' in the key-value pair.",
+          "description": "The 'value' in the key-value.",
           "examples": [
             "blue"
           ],
@@ -47,7 +47,7 @@
         "label": {
           "$id": "#/properties/label",
           "title": "Label",
-          "description": "The label for the key-value pair.",
+          "description": "The label for the key-value.",
           "examples": [
             "staging"
           ],
@@ -64,7 +64,7 @@
         "content_type": {
           "$id": "#/properties/content_type",
           "title": "Content Type",
-          "description": "The content type for the key-value pair.",
+          "description": "The content type for the key-value.",
           "examples": [
             "plaintext"
           ],

--- a/docs/KVSet/KVSet.v1.0.0.schema.json
+++ b/docs/KVSet/KVSet.v1.0.0.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://azconfig.io/schemas/KVSet/v1.0.0/KVSet.json",
-  "title": "An Azure App Configuration schema for importing/exporting using 'appconfig/kvset' format",
+  "title": "An Azure App Configuration schema for importing/exporting using 'appconfig/kvset' profile",
   "type": "object",
   "required": [
     "items"
@@ -21,7 +21,7 @@
     "kv": {
       "type": "object",
       "title": "Key-value",
-      "description": "An individual key-value and associated metadata in the 'appconfig/kvset' format.",
+      "description": "An individual key-value and associated metadata in the 'appconfig/kvset' profile.",
       "properties": {
         "key": {
           "$id": "#/properties/key",
@@ -41,6 +41,7 @@
           "examples": [
             "blue"
           ],
+          "default": null,
           "anyOf": [
             {
               "type": "string"
@@ -57,7 +58,7 @@
           "examples": [
             "staging"
           ],
-          "default": "",
+          "default": null,
           "anyOf": [
             {
               "type": "string"
@@ -88,6 +89,8 @@
           "$id": "#/properties/tags",
           "title": "Tags",
           "type": "object",
+          "default": {
+          },
           "description": "The tags assigned to the key value pair.",
           "additionalProperties": {
             "type": "string"

--- a/docs/KVSet/KVSet.v1.0.0.schema.json
+++ b/docs/KVSet/KVSet.v1.0.0.schema.json
@@ -36,13 +36,19 @@
         },
         "value": {
           "$id": "#/properties/value",
-          "type": "string",
           "title": "Value",
           "description": "The 'value' in the key-value.",
           "examples": [
             "blue"
           ],
-          "pattern": "^(.*)$"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "label": {
           "$id": "#/properties/label",
@@ -51,7 +57,7 @@
           "examples": [
             "staging"
           ],
-          "default": null,
+          "default": "",
           "anyOf": [
             {
               "type": "string"
@@ -68,7 +74,7 @@
           "examples": [
             "plaintext"
           ],
-          "default": null,
+          "default": "",
           "anyOf": [
             {
               "type": "string"
@@ -89,8 +95,7 @@
         }
       },
       "required": [
-        "key",
-        "value"
+        "key"
       ]
     }
   }

--- a/docs/KVSet/KVSet.v1.0.0.schema.json
+++ b/docs/KVSet/KVSet.v1.0.0.schema.json
@@ -41,7 +41,7 @@
           "examples": [
             "blue"
           ],
-          "default": null,
+          "default": "",
           "anyOf": [
             {
               "type": "string"

--- a/docs/KVSet/KVSet.v1.0.0.schema.json
+++ b/docs/KVSet/KVSet.v1.0.0.schema.json
@@ -13,12 +13,12 @@
       "title": "Items",
       "description": "An array of key-values in the Azure App Configuration store.",
       "items": {
-        "$ref" : "#/$defs/kv"
+        "$ref" : "#/$defs/KeyValue"
       }
     }
   },
   "$defs": {
-    "kv": {
+    "KeyValue": {
       "type": "object",
       "title": "Key-value",
       "description": "An individual key-value and associated metadata in the 'appconfig/kvset' profile.",
@@ -73,7 +73,7 @@
           "title": "Content Type",
           "description": "The content type for the key-value.",
           "examples": [
-            "plaintext"
+            "application/json"
           ],
           "default": "",
           "anyOf": [

--- a/docs/KVSet/KVSet.v1.0.0.schema.json
+++ b/docs/KVSet/KVSet.v1.0.0.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://azconfig.io/schemas/KVSet/v1.0.0/KVSet.json",
+  "title": "An Azure App Configuration schema for importing/exporting using 'appconfig/kvset' format",
+  "type": "object",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "items": {
+      "$id": "#/properties/items",
+      "type": "array",
+      "title": "Items",
+      "description": "An array of key-values in the Azure App Configuration store.",
+      "items": {
+        "$ref" : "#/$defs/kv"
+      }
+    }
+  },
+  "$defs": {
+    "kv": {
+      "type": "object",
+      "title": "Key value pair",
+      "description": "An individual key-value pair and associated metadata in the 'appconfig/kvset' format.",
+      "properties": {
+        "key": {
+          "$id": "#/properties/key",
+          "type": "string",
+          "title": "Key",
+          "description": "The 'key' in the key-value pair.",
+          "examples": [
+            "background_color"
+          ],
+          "pattern": "^(.*)$",
+          "minLength": 1
+        },
+        "value": {
+          "$id": "#/properties/value",
+          "type": "string",
+          "title": "Value",
+          "description": "The 'value' in the key-value pair.",
+          "examples": [
+            "blue"
+          ],
+          "pattern": "^(.*)$"
+        },
+        "label": {
+          "$id": "#/properties/label",
+          "title": "Label",
+          "description": "The label for the key-value pair.",
+          "examples": [
+            "staging"
+          ],
+          "default": null,
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "content_type": {
+          "$id": "#/properties/content_type",
+          "title": "Content Type",
+          "description": "The content type for the key-value pair.",
+          "examples": [
+            "plaintext"
+          ],
+          "default": null,
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tags": {
+          "$id": "#/properties/tags",
+          "title": "Tags",
+          "type": "object",
+          "description": "The tags assigned to the key value pair.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "key",
+        "value"
+      ]
+    }
+  }
+}

--- a/docs/KVSet/README.md
+++ b/docs/KVSet/README.md
@@ -1,5 +1,6 @@
 # Azure App Configuration 'appconfig/kvset' profile
 Azure App Configuration can be exported and imported through azure CLI using the `appconfig/kvset` profile.
+The following is the JSON schema used to import and export using `appconfig/kvset` profile - [KVSet.v1.0.0.schema.json](./KVSet.v1.0.0.schema.json).
 
 ## Examples
-Examples of using Azure CLI to export and import key-value pairs using `appconfig/kvset` profile are available at - [examples of exporting kvset](https://docs.microsoft.com/en-us/cli/azure/appconfig/kv?view=azure-cli-latest#az_appconfig_kv_export-examples) and [examples of importing kvset](https://docs.microsoft.com/en-us/cli/azure/appconfig/kv?view=azure-cli-latest#az_appconfig_kv_import).
+Examples of using Azure CLI to export and import key-values using `appconfig/kvset` profile are available at - [examples of exporting kvset](https://docs.microsoft.com/en-us/cli/azure/appconfig/kv?view=azure-cli-latest#az_appconfig_kv_export-examples) and [examples of importing kvset](https://docs.microsoft.com/en-us/cli/azure/appconfig/kv?view=azure-cli-latest#az_appconfig_kv_import).

--- a/docs/KVSet/README.md
+++ b/docs/KVSet/README.md
@@ -1,0 +1,5 @@
+# Azure App Configuration 'appconfig/kvset' profile
+Azure App Configuration can be exported and imported through azure CLI using the `appconfig/kvset` profile.
+
+## Examples
+Examples of using Azure CLI to export and import key-value pairs using `appconfig/kvset` profile are available at - [examples of exporting kvset](https://docs.microsoft.com/en-us/cli/azure/appconfig/kv?view=azure-cli-latest#az_appconfig_kv_export-examples) and [examples of importing kvset](https://docs.microsoft.com/en-us/cli/azure/appconfig/kv?view=azure-cli-latest#az_appconfig_kv_import).

--- a/docs/KVSet/README.md
+++ b/docs/KVSet/README.md
@@ -1,7 +1,5 @@
 # Azure App Configuration 'appconfig/kvset' profile
 
-Azure App Configuration can be exported and imported using Azure CLI version 2.30.0 or later using the `appconfig/kvset` profile.
-
 The following is the JSON schema used to import and export using `appconfig/kvset` profile - [KVSet.v1.0.0.schema.json](./KVSet.v1.0.0.schema.json).
 
 ## Examples

--- a/docs/KVSet/README.md
+++ b/docs/KVSet/README.md
@@ -1,6 +1,11 @@
 # Azure App Configuration 'appconfig/kvset' profile
-Azure App Configuration can be exported and imported through azure CLI using the `appconfig/kvset` profile.
+
+Azure App Configuration can be exported and imported using Azure CLI version 2.30.0 or later using the `appconfig/kvset` profile.
+
 The following is the JSON schema used to import and export using `appconfig/kvset` profile - [KVSet.v1.0.0.schema.json](./KVSet.v1.0.0.schema.json).
 
 ## Examples
+
 Examples of using Azure CLI to export and import key-values using `appconfig/kvset` profile are available at - [examples of exporting kvset](https://docs.microsoft.com/en-us/cli/azure/appconfig/kv?view=azure-cli-latest#az_appconfig_kv_export-examples) and [examples of importing kvset](https://docs.microsoft.com/en-us/cli/azure/appconfig/kv?view=azure-cli-latest#az_appconfig_kv_import).
+
+> **Note:** Importing and exporting Azure App Configuration with `appconfig/kvset` profile is only supported when exporting to or importing from a JSON file using Azure CLI version 2.30.0 or later.


### PR DESCRIPTION
With Azure CLI version `2.30.0`, users can import and export the key-value pairs using the `appconfig/kvset` profile.
This PR adds JSON Schema to validate the JSON file using `appconfig/kvset` profile and points examples to using Azure CLI to import and export.