### PR TITLE
ConfigurationStoreBackup sample - Upgraded to .NET 6 and fixed the KeyLabel comparer issue

### DIFF
--- a/examples/ConfigurationStoreBackup/ConfigurationStoreBackup.csproj
+++ b/examples/ConfigurationStoreBackup/ConfigurationStoreBackup.csproj
@@ -1,13 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Data.AppConfiguration" Version="1.0.0" />
-    <PackageReference Include="Azure.Identity" Version="1.1.1" />
-    <PackageReference Include="Azure.Storage.Queues" Version="12.11.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.6" />
+	<PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="5.2.0" />
+    <PackageReference Include="Azure.Identity" Version="1.8.2" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.12.0" />
+	<PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/examples/ConfigurationStoreBackup/ConfigurationStoreBackup.csproj
+++ b/examples/ConfigurationStoreBackup/ConfigurationStoreBackup.csproj
@@ -4,10 +4,10 @@
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-	<PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="5.2.0" />
+    <PackageReference Include="Azure.Data.AppConfiguration" Version="1.2.0" />
     <PackageReference Include="Azure.Identity" Version="1.8.2" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.12.0" />
-	<PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/examples/ConfigurationStoreBackup/KeyLabel.cs
+++ b/examples/ConfigurationStoreBackup/KeyLabel.cs
@@ -13,6 +13,16 @@ namespace ConfigurationStoreBackup
             Label = label ?? string.Empty;
         }
 
+        public override bool Equals(Object obj)
+        {
+            if (obj is KeyLabel keyLabel)
+            {
+                return string.Equals(this.Key, keyLabel.Key, StringComparison.Ordinal)
+                    && string.Equals(this.Label, keyLabel.Label, StringComparison.Ordinal);
+            }
+            return false;
+        }
+
         public override int GetHashCode()
         {
             return this.Label != null ? this.Key.GetHashCode() ^ this.Label.GetHashCode() : this.Key.GetHashCode();

--- a/examples/ConfigurationStoreBackup/KeyLabel.cs
+++ b/examples/ConfigurationStoreBackup/KeyLabel.cs
@@ -10,17 +10,7 @@ namespace ConfigurationStoreBackup
         public KeyLabel(string key, string label)
         {
             Key = key;
-            Label = label;
-        }
-
-        public override bool Equals(Object obj)
-        {
-            if (obj is KeyLabel keyLabel)
-            {
-                return string.Equals(this.Key, keyLabel.Key, StringComparison.Ordinal)
-                    && string.Equals(this.Label, keyLabel.Label, StringComparison.Ordinal);
-            }
-            return false;
+            Label = label ?? string.Empty;
         }
 
         public override int GetHashCode()


### PR DESCRIPTION
This addresses an issue with the sample code from this scenario:
https://learn.microsoft.com/en-us/azure/azure-app-configuration/howto-backup-config-store

Fixed an issue where the KeyLabel Equals override was not working with the current behaviour in Azure. When an app config key was being updated (with or without a Label), it was never matched against the keys found in the app config store. 

Also upgraded to .NET 6 and changed the NuGet package references to work with Azure Functions runtime v4.

Deployed updated code to Azure portal and it resolved the issue. Tested with the following scenarios:
- Added a new key to the primary store and the key was synchronized over to the secondary store (added).
- Updated existing key in the primary store and the key was synchronized over to the secondary store (updated).
- Deleted an existing key from the primary store and the key was synchronized over to the secondary store (deleted).
- Tested the above for keys with and without Labels.