### PR TITLE
update link and keep old version schema

### DIFF
--- a/docs/FeatureManagement/FeatureFlag.v1.0.0.schema.json
+++ b/docs/FeatureManagement/FeatureFlag.v1.0.0.schema.json
@@ -1,0 +1,122 @@
+{
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://azconfig.io/schemas/FeatureManagement/v1.0.0/FeatureFlag.json",
+  "type": "object",
+  "title": "An Azure App Configuration Feature Declaration",
+  "required": [
+    "id",
+    "enabled",
+    "conditions"
+  ],
+  "properties": {
+    "id": {
+      "$id": "#/properties/id",
+      "type": "string",
+      "title": "Feature ID",
+      "description": "An ID used to uniquely identify and reference the feature.",
+      "examples": [
+        "fancy-background"
+      ],
+      "pattern": "^(.*)$"
+    },
+    "description": {
+      "$id": "#/properties/description",
+      "type": "string",
+      "title": "Feature Description",
+      "description": "A description of the feature.",
+      "default": "",
+      "examples": [
+        "This will display a fancy background on the home page."
+      ],
+      "pattern": "^[a-zA-Z0-9_\\-\\.]*$"
+    },
+    "display_name": {
+      "$id": "#/properties/display_name",
+      "type": "string",
+      "title": "Feature Display Name",
+      "description": "A display name for the feature to use for display rather than the ID.",
+      "default": "",
+      "examples": [
+        "Fancy Background"
+      ],
+      "pattern": "^(.*)$"
+    },
+    "enabled": {
+      "$id": "#/properties/enabled",
+      "type": "boolean",
+      "title": "Enabled State",
+      "description": "A feature is OFF if enabled is false. If enabled is true, then the feature is ON if there are no conditions (null or empty) or if all conditions are satisfied.",
+      "default": false
+    },
+    "conditions": {
+      "$id": "#/properties/conditions",
+      "type": "object",
+      "title": "Feature Enablement Conditions",
+      "description": "The declaration of conditions used to dynamically enable features.",
+      "required": [],
+      "properties": {
+        "client_filters": {
+          "$id": "#/properties/conditions/properties/client_filters",
+          "type": "array",
+          "title": "Client Filter Collection",
+          "description": "Filters that must run on the client and be evaluated as true for the feature to be considered enabled.",
+          "items": {
+            "$id": "#/properties/conditions/properties/client_filters/items",
+            "type": "object",
+            "title": "Client Filter",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "$id": "#/properties/conditions/properties/client_filters/items/properties/name",
+                "type": "string",
+                "title": "Client Filter Name",
+                "description": "The name used to refer to and require a client filter.",
+                "default": "",
+                "examples": [
+                  "Percentage",
+                  "TimeWindow"
+                ],
+                "pattern": "^(.*)$"
+              },
+              "parameters": {
+                "$id": "#/properties/conditions/properties/client_filters/items/properties/parameters",
+                "type": "object",
+                "title": "Client Filter Parameters",
+                "description": "Custom parameters for a given client filter. A client filter can require any set of parameters of any type.",
+                "required": [],
+                "patternProperties": {
+                  "^.*$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "object"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "array"
+                      },
+                      {
+                        "type": "boolean"
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/FeatureManagement/readme.md
+++ b/docs/FeatureManagement/readme.md
@@ -8,6 +8,6 @@ All feature flag key-values are prefixed with ".appconfig.featureflag/" to disti
 
 The following are the currently used content types in Azure App Configuration feature management:
 
-[application/vnd.microsoft.appconfig.ff+json;charset=utf-8](./FeatureFlag.v1.0.0.schema.json)
+[application/vnd.microsoft.appconfig.ff+json;charset=utf-8](./FeatureFlag.v1.1.0.schema.json)
 
 


### PR DESCRIPTION
Schema link in readme is broken, pointing to v1.0.0 which has been deleted. We probably should keep schema of old version for reference when we publish new version. 

This PR restore the old v1.0.0 schema file, and update the link pointing to the latest (v1.1.0) one.