### PR TITLE
Include depth in example of breaking change importing configurations with JSON content types

### DIFF
--- a/releaseNotes/AzureDevOpsPushPipelineExtension.md
+++ b/releaseNotes/AzureDevOpsPushPipelineExtension.md
@@ -6,8 +6,7 @@ Azure App Configuration Push extension for Azure DevOps pipeline can be installe
 **Breaking Changes**
   - Updated the task to require Node.js 16. It previously required 10.
   - Updated the minimum supported azure pipeline agent version to [2.206.1](https://github.com/microsoft/azure-pipelines-agent/releases/tag/v2.206.1) or later. Previously it was [2.144.0](https://github.com/microsoft/azure-pipelines-agent/releases/tag/v2.144.0).
-  - The behavior when importing configurations with JSON content types such as `application/json` or `application/vnd.mycustomresource+json` has changed. The properties in the provided configuration are serialized as JSON to respect the provided content type. Settings that are expected to end up as JSON serialized strings in App Configuration should now be specified as JSON objects.
-
+  - The behavior when importing configurations with JSON content types such as `application/json` or `application/vnd.mycustomresource+json` has changed. The properties in the provided configuration are serialized as JSON to respect the provided content type. Settings that are expected to end up as JSON serialized strings in App Configuration should now be specified as JSON objects. Additionally, the depth property should also be adjusted to match the expected depth of the JSON structure.
 
     **Before**
     ```

--- a/releaseNotes/AzureDevOpsPushPipelineExtension.md
+++ b/releaseNotes/AzureDevOpsPushPipelineExtension.md
@@ -35,6 +35,7 @@ Azure App Configuration Push extension for Azure DevOps pipeline can be installe
     inputs:
       azureSubscription: '<subscription>'
       AppConfigurationEndpoint: '<store endpoint>'
+      Depth: 1
       ....
       ContentType: 'application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8'
 

--- a/releaseNotes/AzureDevOpsPushPipelineExtension.md
+++ b/releaseNotes/AzureDevOpsPushPipelineExtension.md
@@ -6,7 +6,7 @@ Azure App Configuration Push extension for Azure DevOps pipeline can be installe
 **Breaking Changes**
   - Updated the task to require Node.js 16. It previously required 10.
   - Updated the minimum supported azure pipeline agent version to [2.206.1](https://github.com/microsoft/azure-pipelines-agent/releases/tag/v2.206.1) or later. Previously it was [2.144.0](https://github.com/microsoft/azure-pipelines-agent/releases/tag/v2.144.0).
-  - The behavior when importing configurations with JSON content types such as `application/json` or `application/vnd.mycustomresource+json` has changed. The properties in the provided configuration are serialized as JSON to respect the provided content type. Settings that are expected to end up as JSON serialized strings in App Configuration should now be specified as JSON objects. Additionally, the depth property should also be adjusted to match the expected depth of the JSON structure.
+  - The behavior when importing configurations with JSON content types such as `application/json` or `application/vnd.mycustomresource+json` has changed. The properties in the provided configuration are serialized as JSON to respect the provided content type. Settings that are expected to end up as JSON serialized strings in App Configuration should now be specified as JSON objects. Additionally, the depth property should also be adjusted to match the expected depth the JSON structure will be flattened to.
 
     **Before**
     ```


### PR DESCRIPTION
Include the depth property  in example of breaking change when importing configurations with JSON content types