### PR TITLE
Update $ref in FeatureManagement schema json

### DIFF
--- a/docs/FeatureManagement/FeatureManagement.v1.0.0.schema.json
+++ b/docs/FeatureManagement/FeatureManagement.v1.0.0.schema.json
@@ -23,7 +23,7 @@
                     "title": "Feature Flags",
                     "description": "Declares feature flags based on Microsoft Feature Flag schema.",
                     "items": {
-                        "$ref": "https://github.com/Azure/AppConfiguration/blob/main/docs/FeatureManagement/FeatureFlag.v1.1.0.schema.json"
+                        "$ref": "https://raw.githubusercontent.com/Azure/AppConfiguration/main/docs/FeatureManagement/FeatureFlag.v1.1.0.schema.json"
                     }
                 }
             }


### PR DESCRIPTION
https://json-schema.org/understanding-json-schema/structuring#dollarref

AFAIU, `$ref` should points to another JSON schema instead of a GH page. 

And it also breaks some schema validation tools, which download related schemas from `$ref` to perform the validation.