### PR TITLE
Add package.json for javascript example

### DIFF
--- a/examples/QuickStart/JavaScript/QuickStartApp/package.json
+++ b/examples/QuickStart/JavaScript/QuickStartApp/package.json
@@ -1,0 +1,5 @@
+{
+    "dependencies": {
+        "@azure/app-configuration-provider": "latest"
+    }
+}


### PR DESCRIPTION
With package.json, user can run `npm install` to install the dependencies of the quickstart project.